### PR TITLE
Fixing syntax error in JS code.

### DIFF
--- a/core-transition.html
+++ b/core-transition.html
@@ -131,7 +131,7 @@ Fired when the animation finishes.
         var listener = function() {
           fn.apply(self, args);
           node.removeEventListener(event, listener, false);
-        }
+        };
         node.addEventListener(event, listener, false);
       }
 


### PR DESCRIPTION
Missing semi-colon proves to be a problem when this JS code is compressed to exclude white spaces.